### PR TITLE
Implement Slack Service as NPM Package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 *.tgz
 .env
+test-send.ts

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 *.tgz
 .env
 release_notes
+test-send.ts

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ svc.sendMessage(`new message at ${new Date().toISOString()}`);
    <summary>
       Release notes - current
    </summary>
-   <a href="/release_notes/2025_06_04.md">2025-06-04</a> - <br />
+   <a href="/release_notes/2025_06_04.md">2025-06-04</a> - Implement Slack Service as NPM Package<br />
 </details>
 
 ---

--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ svc.sendMessage(`new message at ${new Date().toISOString()}`);
 
 # TODO: Migrate / consolidate slack code in other apps to this repo/package.
 
+# Release Notes
+
+<details>
+   <summary>
+      Release notes - current
+   </summary>
+   <a href="/release_notes/2025_06_04.md">2025-06-04</a> - <br />
+</details>
+
 ---
 
 # Notes about Developing the Package

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rri-slack-np",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rri-slack-np",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "ISC",
       "dependencies": {
         "@slack/web-api": "^7.9.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,12 @@
       "dependencies": {
         "@slack/web-api": "^7.9.2",
         "dotenv": "^16.5.0",
+        "json2csv": "^6.0.0-alpha.2",
         "typescript": "^5.8.3"
       },
       "devDependencies": {
         "@types/chai": "^5.2.2",
+        "@types/json2csv": "^5.0.7",
         "@types/mocha": "^10.0.10",
         "@types/node": "^22.15.20",
         "@types/sinon": "^17.0.4",
@@ -183,6 +185,12 @@
         "npm": ">= 8.6.0"
       }
     },
+    "node_modules/@streamparser/json": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@streamparser/json/-/json-0.0.6.tgz",
+      "integrity": "sha512-vL9EVn/v+OhZ+Wcs6O4iKE9EUpwHUqHmCtNUMWjqp+6dr85+XPOSGTEsqYNq1Vn04uk9SWlOVmx9J48ggJVT2Q==",
+      "license": "MIT"
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -227,6 +235,16 @@
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/json2csv": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@types/json2csv/-/json2csv-5.0.7.tgz",
+      "integrity": "sha512-Ma25zw9G9GEBnX8b12R4EYvnFT6dBh8L3jwsN5EUFXa+fl2dqmbLDbNWN0XuQU3rSXdsbBeCYjI9uHU2PUBxhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/mocha": {
       "version": "10.0.10",
@@ -594,6 +612,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/create-require": {
@@ -1106,6 +1133,24 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json2csv": {
+      "version": "6.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-6.0.0-alpha.2.tgz",
+      "integrity": "sha512-nJ3oP6QxN8z69IT1HmrJdfVxhU1kLTBVgMfRnNZc37YEY+jZ4nU27rBGxT4vaqM/KUCavLRhntmTuBFqZLBUcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@streamparser/json": "^0.0.6",
+        "commander": "^6.2.0",
+        "lodash.get": "^4.4.2"
+      },
+      "bin": {
+        "json2csv": "bin/json2csv.js"
+      },
+      "engines": {
+        "node": ">= 12",
+        "npm": ">= 6.13.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -1127,7 +1172,6 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/log-symbols": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rri-slack-np",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
   "dependencies": {
     "@slack/web-api": "^7.9.2",
     "dotenv": "^16.5.0",
+    "json2csv": "^6.0.0-alpha.2",
     "typescript": "^5.8.3"
   },
   "devDependencies": {
     "@types/chai": "^5.2.2",
+    "@types/json2csv": "^5.0.7",
     "@types/mocha": "^10.0.10",
     "@types/node": "^22.15.20",
     "@types/sinon": "^17.0.4",

--- a/release_notes/2025_06_04.md
+++ b/release_notes/2025_06_04.md
@@ -1,0 +1,12 @@
+# Dead Letter Queue Features
+
+* [Jira Item](https://rri-it.atlassian.net/browse/RS-1765)
+* [Pull Request](https://github.com/rri-dev/rri-core-api-v3/pull/1)
+
+# Summary
+
+* creates an npm package that wraps `@slack/web-api` with some convenient methods
+* `sendMessage` - accepts a string, and optional channel id
+* `sendCsv` - accepts a header string array, and rows object to send a csv file to the slack channel
+* `sendCsvFromObjectArray` - accepts an object array, and sends a csv file to the slack channel
+    - sending flattened objects is recommended as they parse better into a _CSV_

--- a/release_notes/2025_06_04.md
+++ b/release_notes/2025_06_04.md
@@ -1,4 +1,4 @@
-# Dead Letter Queue Features
+# Implement Slack Service as NPM Package
 
 * [Jira Item](https://rri-it.atlassian.net/browse/RS-1765)
 * [Pull Request](https://github.com/rri-dev/rri-core-api-v3/pull/1)

--- a/src/slack-service.ts
+++ b/src/slack-service.ts
@@ -1,5 +1,8 @@
 import { WebClient } from '@slack/web-api';
 import dotenv from 'dotenv';
+import fs from 'fs';
+import os from 'os';
+import { Parser } from 'json2csv';
 dotenv.config();
 export class SlackService {
     client: WebClient;
@@ -24,6 +27,11 @@ export class SlackService {
         this.defaultChannel = defaultChannel;
     }
 
+    randStr(length: number) {
+        if (length > 128) throw new Error(`max length supported is 128`);
+        return require("crypto").randomBytes(64).toString("hex").slice(0,length);
+    }
+
     async sendMessage(message: string, channelId?: string): Promise<void> {
 
         const logPrefix = '::SlackService--sendMessage::';
@@ -39,6 +47,78 @@ export class SlackService {
             if(this.debug) console.log(`${logPrefix}error: ${err.message}`);
         }
 
+    }
+
+    async sendCsv(headers: string[], rows: Record<string, string>[], channelId?: string): Promise<void> {
+
+        const logPrefix = '::service--SlackService--sendCsvContent::';
+        const channel = channelId || this.defaultChannel;
+
+        const tempDir = os.tmpdir(), fileName = this.randStr(10);
+        const tempFilePath = `${tempDir}/${fileName}.csv`;
+        
+        try {
+
+            const csv = headers.join(',') + '\n' + rows.map(row =>
+                headers.map(header => `"${String(row[header]).replace(/"/g, "")}"`).join(','),
+            ).join('\n');
+
+            console.log('csv:',csv);
+
+            fs.writeFileSync(tempFilePath, csv);
+            console.log(`file written to temp directory: ${tempFilePath}`);
+
+            await this.client.files.uploadV2({
+                channel_id: channel,
+                file: fs.createReadStream(tempFilePath),
+                filename: tempFilePath.split('/').pop(),
+                title: fileName,
+            });
+
+            console.log(`${logPrefix} Uploaded CSV to Slack channel ${channel}`);
+
+        } catch (err: any) {
+            console.log(`${logPrefix} error: ${err.message}`);
+            throw err;
+
+        } finally{
+            if(fs.existsSync(tempFilePath)) {
+                fs.unlinkSync(tempFilePath);
+            }
+        }
+    }
+
+    async sendCsvFromObjectArray(objs: any[], channelId?: string): Promise<void> {
+
+        const logPrefix = '::service--SlackService--sendCsvFromObject::';
+
+        const tempDir = os.tmpdir(), fileName = this.randStr(10);
+        const tempFilePath = `${tempDir}/${fileName}.csv`;
+
+        try {
+            const parser = new Parser();
+            const csvStr = parser.parse(objs);
+            const channel = channelId || this.defaultChannel;
+            
+            fs.writeFileSync(tempFilePath, csvStr);
+            if (this.debug) console.log(`file written to temp directory: ${tempFilePath}`);
+
+            await this.client.files.uploadV2({
+                channel_id: channel,
+                file: fs.createReadStream(tempFilePath),
+                filename: tempFilePath.split('/').pop(),
+                title: fileName,
+            });
+
+            if (this.debug) console.log(`${logPrefix} Uploaded CSV to Slack channel ${channel}`);
+        } catch (err: any) {
+            console.log(`${logPrefix} error: ${err.message}`);
+            throw err;
+        } finally {
+            if (fs.existsSync(tempFilePath)) {
+                fs.unlinkSync(tempFilePath);
+            }
+        }
     }
     
 }


### PR DESCRIPTION
# Implement Slack Service as NPM Package

* [Jira Item](https://rri-it.atlassian.net/browse/RS-1765)
* [Pull Request](https://github.com/rri-dev/rri-core-api-v3/pull/1)

# Summary

* creates an npm package that wraps `@slack/web-api` with some convenient methods
* `sendMessage` - accepts a string, and optional channel id
* `sendCsv` - accepts a header string array, and rows object to send a csv file to the slack channel
* `sendCsvFromObjectArray` - accepts an object array, and sends a csv file to the slack channel
    - sending flattened objects is recommended as they parse better into a _CSV_